### PR TITLE
A new way to get element with context

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -199,12 +199,12 @@ Take this example where there are more than one login form on the page:
 
     <html>
         <body>
-            <form id="login-1" type="POST" action="/login-1">
+            <form id="form-1" type="POST" action="/login-1">
                 <input type="text" name="username"></input>
                 <input type="password" name="password"></input>
                 <input type="submit">Submit</input>
             </form>
-            <form id="login-2" type="POST" action="/login-2">
+            <form id="form-2" type="POST" action="/login-2">
                 <input type="text" name="username"></input>
                 <input type="password" name="password"></input>
                 <input type="submit">Submit</input>
@@ -222,18 +222,25 @@ You could have separate page elements for each form input, like this:
             submit_2 = PageElement(css='#form-2 input[type="submit"]')
 
 
-However, you can also construct the page elements with the ``context`` flag set like this:
+However, you can also construct the page elements with the ``context`` like this:
 
 .. code-block:: python
 
     >>> class LoginPage(PageObject):
             form1 = PageElement(id_='form-1')
-            form2 = PageElement(id_='form-1')
-            submit = PageElement(css='input[type="submit"]', context=True)
+            form2 = PageElement(id_='form-2')
+            submit1 = PageElement(css='input[type="submit"]', context='form1')
+            submit2 = PageElement(css='input[type="submit"]', context='form2')
 
-
-This allows you to access the submit element *within* a form element, by calling
+Or you can access the submit element *within* a form element, by calling
 the submit element like you would a method:
+
+.. code-block:: python
+
+    >>> class LoginPage(PageObject):
+            form1 = PageElement(id_='form-1')
+            form2 = PageElement(id_='form-2')
+            submit = PageElement(css='input[type="submit"]')
 
 .. code-block:: python
 

--- a/page_objects/__init__.py
+++ b/page_objects/__init__.py
@@ -55,8 +55,8 @@ class PageElement(object):
     :param class_name:    `str`
         Use this class locator
 
-    :param context: `bool`
-        This element is expected to be called with context
+    :param context: `str`
+        This element is expected to be called with PageObject.context
 
     Page Elements are used to access elements on a page. The are constructed
     using this factory method to specify the locator for the element.
@@ -65,19 +65,19 @@ class PageElement(object):
         >>> class MyPage(PageObject):
                 elem1 = PageElement(css='div.myclass')
                 elem2 = PageElement(id_='foo')
-                elem_with_context = PageElement(name='bar', context=True)
+                elem_with_context = PageElement(name='bar', context='elem1')
 
     Page Elements act as property descriptors for their Page Object, you can get
     and set them as normal attributes.
     """
-    def __init__(self, context=False, **kwargs):
+    def __init__(self, context=None, **kwargs):
         if not kwargs:
             raise ValueError("Please specify a locator")
         if len(kwargs) > 1:
             raise ValueError("Please specify only one locator")
         k, v = next(iter(kwargs.items()))
         self.locator = (_LOCATOR_MAP[k], v)
-        self.has_context = bool(context)
+        self.context = context
 
     def find(self, context):
         try:
@@ -89,17 +89,15 @@ class PageElement(object):
         if not instance:
             return None
 
-        if not context and self.has_context:
-            return lambda ctx: self.__get__(instance, owner, context=ctx)
-
         if not context:
-            context = instance.w
+            if self.context:
+                context = instance.__getattribute__(self.context)
+            else:
+                context = instance.w
 
         return self.find(context)
 
     def __set__(self, instance, value):
-        if self.has_context:
-            raise ValueError("Sorry, the set descriptor doesn't support elements with context.")
         elem = self.__get__(instance, instance.__class__)
         if not elem:
             raise ValueError("Can't set value, element not found")
@@ -122,8 +120,6 @@ class MultiPageElement(PageElement):
             return []
 
     def __set__(self, instance, value):
-        if self.has_context:
-            raise ValueError("Sorry, the set descriptor doesn't support elements with context.")
         elems = self.__get__(instance, instance.__class__)
         if not elems:
             raise ValueError("Can't set value, no elements found")

--- a/tests/test_page_objects.py
+++ b/tests/test_page_objects.py
@@ -53,13 +53,12 @@ class TestGet:
 
     def test_get_element_with_context(self, webdriver):
         class TestPage(PageObject):
-            test_elem = PageElement(css='bar', context=True)
+            elem = mock.Mock(spec=WebElement, name="My Elem")
+            test_elem = PageElement(css='bar', context='elem')
 
         page = TestPage(webdriver=webdriver)
-        elem = mock.Mock(spec=WebElement, name="My Elem")
-        res = page.test_elem(elem)
-        assert elem.find_element.called_once_with(By.CSS_SELECTOR, 'bar')
-        assert res == elem.find_element.return_value
+        assert page.elem.find_element.called_once_with(By.CSS_SELECTOR, 'bar')
+        assert page.test_elem == page.elem.find_element.return_value
 
     def test_get_not_found(self, webdriver):
         class TestPage(PageObject):
@@ -102,15 +101,6 @@ class TestSet:
         assert webdriver.find_elements.called_once_with(By.CSS_SELECTOR, 'foo')
         elem.send_keys.assert_called_once_with('XXX')
 
-    def test_cannot_set_with_context(self, webdriver):
-        class TestPage(PageObject):
-            test_elem = PageElement(css='foo', context=True)
-
-        page = TestPage(webdriver=webdriver)
-        with pytest.raises(ValueError) as e:
-            page.test_elem = 'xxx'
-        assert "doesn't support elements with context" in e.value.args[0]
-
     def test_cannot_set_not_found(self, webdriver):
         class TestPage(PageObject):
             test_elem = PageElement(css='foo')
@@ -134,15 +124,6 @@ class TestSet:
         assert webdriver.find_elements.called_once_with(By.CSS_SELECTOR, 'foo')
         elem1.send_keys.assert_called_once_with('XXX')
         elem2.send_keys.assert_called_once_with('XXX')
-
-    def test_cannot_set_multi_with_context(self, webdriver):
-        class TestPage(PageObject):
-            test_elem = MultiPageElement(css='foo', context=True)
-
-        page = TestPage(webdriver=webdriver)
-        with pytest.raises(ValueError) as e:
-            page.test_elem = 'xxx'
-        assert "doesn't support elements with context" in e.value.args[0]
 
     def test_cannot_set_multi_not_found(self, webdriver):
         class TestPage(PageObject):


### PR DESCRIPTION
I added a new way to get element with context, while the old way is still available.
```python
class LoginPage(PageObject):
    form1 = PageElement(id_='form-1')
    form2 = PageElement(id_='form-2')
    submit1 = PageElement(css='input[type="submit"]', context='form1')
    submit2 = PageElement(css='input[type="submit"]', context='form2')
    submit = PageElement(css='input[type="submit"]')

page = LoginPage()
page.submit1.click()
page.submit(page.form1).click()
```
